### PR TITLE
Fix slowest query report

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,12 +62,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
-      mimemagic (~> 0.3.2)
+    marcel (1.0.0)
     method_source (0.9.0)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)

--- a/lib/sql_query_stats/sanitizer.rb
+++ b/lib/sql_query_stats/sanitizer.rb
@@ -10,14 +10,16 @@ module SqlQueryStats
 
     def self.filter_params(filters, sql)
       filters.each do |filter|
-        sql.gsub!(/`#{filter}` = '[^']+'/, "#{filter} = '[FILTERED]'")
+        sql.gsub!(/`#{filter}` = '[^']+'/, "`#{filter}` = '[FILTERED]'")
       end
 
       sql
     end
 
     def self.filter_values(sql)
-      sql.gsub!(/(?:VALUES(?:\s?)\()(.*)(?:\)+)/, 'VALUES(?)')
+      sql.gsub!(/(?:VALUES(?:\s?)\()(.*)(?:\)+)/, 'VALUES (?)')
+
+      sql
     end
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -3,7 +3,6 @@ require_relative 'boot'
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
-require "query_stats"
 
 module Dummy
   class Application < Rails::Application

--- a/test/sql_query_stats/sanitizer_test.rb
+++ b/test/sql_query_stats/sanitizer_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module SqlQueryStats
+  class SanitizerTest < ActiveSupport::TestCase
+    test '.filter_params filters successfully' do
+      original = "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'test' AND `users`.`password` = 'password'"
+      expected = "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'test' AND `users`.`password` = '[FILTERED]'"
+
+      result = SqlQueryStats::Sanitizer.filter_params([:password], original)
+      assert_equal(expected, result)
+    end
+
+    test '.filter_params makes no change' do
+      original = "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'test'"
+
+      result = SqlQueryStats::Sanitizer.filter_params([:password], original)
+      assert_equal(original, result)
+    end
+
+    test '.filter_values filters successfully' do
+      original = "INSERT INTO `users` (`id`, `name`, `password`) VALUES (1, 'name', 'password')"
+      expected = "INSERT INTO `users` (`id`, `name`, `password`) VALUES (?)"
+
+      result = SqlQueryStats::Sanitizer.filter_values(original)
+      assert_equal(expected, result)
+    end
+
+    test '.filter_values makes no change' do
+      original = "SELECT `users`.* FROM `users` WHERE `users`.`name` = 'test'"
+
+      result = SqlQueryStats::Sanitizer.filter_values(original)
+      assert_equal(original, result)
+    end
+  end
+end


### PR DESCRIPTION
`SlowestQuery` always report empty, I think it because of Sanitizer filter the query which not contains `VALUES` parts.

I fixed `SqlQueryStats::Sanitizer.filter_values` method, not to sanitize all queries that not hit regex.
and this pull request also contains some cleaning. please review !